### PR TITLE
Kf/testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/core": "^7.21.3",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
+    "@types/jest": "^29.5.1",
     "babel-loader": "^9.1.2",
     "css-loader": "^6.7.3",
     "eslint": "^8.37.0",

--- a/server/controller/dalleImageController.js
+++ b/server/controller/dalleImageController.js
@@ -1,64 +1,25 @@
-const { Configuration, OpenAIApi } = require('openai');
-const fs = require('fs/promises');
-const path = require('path');
-const { Readable } = require('stream');
 const { uploadeFileToS3 } = require('../utils/awsS3Connection');
-
-const configuration = new Configuration({
-  apiKey: process.env.DALLE_KEY,
-});
-
-// create openAi client
-const openai = new OpenAIApi(configuration);
-
-const convertStrToFileName = (str) =>
-  `${str.toLowerCase().replace(/\s/gi, '-')}.jpg`;
+const convertStrToFileName = require('../utils/convertStrToFileName');
+const { generateImage } = require('../services/dalleService');
 
 const dalleImageController = {};
 
-dalleImageController.generateImage = async (req, res, next) => {
+dalleImageController.getImageUrl = async (req, res, next) => {
   const { imagePath } = req.body;
   if (!imagePath) {
     try {
       const { title } = req.body;
-      const response = await openai.createImage({
-        prompt: title,
-        n: 1,
-        size: '256x256',
-      });
-      
-      // convert png to readable stream of byte data for S3 upload
-      const imageUrl = response.data.data[0].url;
-      const imageResponse = await fetch(imageUrl);
-      const blob = await imageResponse.blob();
-      const arrayBuffer = await blob.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      const stream = Readable.from(buffer);
       const imageFileName = convertStrToFileName(title);
+      const b64Image = await generateImage(title);
+      const buffer = Buffer.from(b64Image, 'base64');
 
-      // Save a file to local disk. Not used.
-      /*
-      await fs.writeFile(
-        path.join(__dirname, '../../public/images/', imageFileName),
-        buffer
-      );
-      */
-
-      // Upload the image stream to AWS S3 bucket.
-      /*
-        TO-DO: 1. Add userid to the imageFileName to be saved in AWS S3.
-        2. Any performance optimization for the process of fetching from DALL-E url and then uploading to AWS S3.
-      */
-
-      const s3result = await uploadeFileToS3(imageFileName, stream);
-
+      const s3result = await uploadeFileToS3(imageFileName, buffer);
       res.locals.awsimagePath = s3result.Location;
 
       return next();
     } catch (error) {
-      console.log("error in dalle-ai")
       return next({
-        log: `Error encountered in dalleImageController.generateImage, ${error}`,
+        log: `Error encountered in dalleImageController.getImageUrl, ${error}`,
         message: 'Error encountered when generating image via the DallE AI.',
       });
     }

--- a/server/controller/dalleImageController.js
+++ b/server/controller/dalleImageController.js
@@ -10,7 +10,7 @@ dalleImageController.getImageUrl = async (req, res, next) => {
     try {
       const { title } = req.body;
       const imageFileName = convertStrToFileName(title);
-      const b64Image = await generateImage(title);
+      const b64Image = (await generateImage(title)).b64_json;
       const buffer = Buffer.from(b64Image, 'base64');
 
       const s3result = await uploadeFileToS3(imageFileName, buffer);

--- a/server/controller/databaseController.js
+++ b/server/controller/databaseController.js
@@ -139,13 +139,6 @@ databaseController.updateImage = (req, res, next) => {
         res.locals.imagePath !== oldImagePath
       ) {
         return deleteFileFromS3(oldImagePath);
-
-        // Delete the image file on local disk. Not used.
-        /*
-        return fs.unlink(
-          path.join(__dirname, '../../public/images/', res.locals.oldimagepath)
-        );
-        */
       }
       return null;
     })
@@ -180,13 +173,6 @@ databaseController.deleteRecipe = (req, res, next) => {
         )
       ) {
         return deleteFileFromS3(imagePath);
-
-        // Delete the image file on local disk. Not used.
-        /*
-        return fs.unlink(
-          path.join(__dirname, '../../public/images/', imagePath)
-        );
-        */
       }
       return null;
     })

--- a/server/routes/recipeRoute.js
+++ b/server/routes/recipeRoute.js
@@ -16,7 +16,7 @@ router.get('/all', databaseController.getAllRecipes, (req, res, next) => {
 // Add a new recipe to the database
 router.post(
   '/add',
-  dalleImageController.generateImage,
+  dalleImageController.getImageUrl,
   databaseController.addRecipe,
   (req, res, next) => {
     res.status(200).json(res.locals);
@@ -31,7 +31,7 @@ router.put('/update/:id', databaseController.updateRecipe, (req, res, next) => {
 // Update a recipe image with a specific id in the database. The request shall have the recipe id in url parameter and recipe title in the body.
 router.put(
   '/update/image/:id',
-  dalleImageController.generateImage,
+  dalleImageController.getImageUrl,
   databaseController.updateImage,
   (req, res, next) => {
     res.status(200).json(res.locals);

--- a/server/services/dalleService.js
+++ b/server/services/dalleService.js
@@ -1,0 +1,16 @@
+const openai = require('../utils/openAi');
+
+const dalleService = {};
+
+dalleService.generateImage = async (prompt) => {
+  const response = await openai.createImage({
+    prompt: prompt,
+    n: 1,
+    size: '256x256',
+    response_format: 'b64_json',
+  });
+
+  return response.data.data[0].b64_json;
+}
+
+module.exports = dalleService;

--- a/server/services/dalleService.js
+++ b/server/services/dalleService.js
@@ -10,7 +10,7 @@ dalleService.generateImage = async (prompt) => {
     response_format: 'b64_json',
   });
 
-  return response.data.data[0].b64_json;
+  return response.data.data[0];
 }
 
 module.exports = dalleService;

--- a/server/utils/convertStrToFileName.js
+++ b/server/utils/convertStrToFileName.js
@@ -1,0 +1,2 @@
+module.exports = (str) =>
+`${str.toLowerCase().replace(/\s/gi, '-')}.jpg`;

--- a/server/utils/openAi.js
+++ b/server/utils/openAi.js
@@ -1,0 +1,9 @@
+const { Configuration, OpenAIApi } = require('openai');
+
+const configuration = new Configuration({
+  apiKey: process.env.DALLE_KEY,
+});
+
+const openai = new OpenAIApi(configuration);
+
+module.exports = openai;

--- a/tests/server/services/dalleService.test.js
+++ b/tests/server/services/dalleService.test.js
@@ -1,0 +1,38 @@
+const { generateImage } = require('../../../server/services/dalleService');
+const openai = require('../../../server/utils/openAi');
+
+jest.mock('openai');
+
+openai.createImage.mockResolvedValue({
+  data: {
+    data: [
+      {
+        b64_json: 'base 64 encoded string'
+      }
+    ]
+  }
+});
+
+const testPrompt = 'test recipe'
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should generate a string', async () => {
+  const string = await generateImage(testPrompt);
+
+  expect(typeof string).toBe('string');
+})
+
+it('should not respond with a url', async () => {
+  const string = await generateImage(testPrompt);
+
+  expect(string).not.toContain('https://')
+})
+
+it('should only call dalleAPI once', async () => {
+  await generateImage(testPrompt);
+
+  expect(openai.createImage).toHaveBeenCalledTimes(1);
+})

--- a/tests/server/services/dalleService.test.js
+++ b/tests/server/services/dalleService.test.js
@@ -19,16 +19,10 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-it('should generate a string', async () => {
-  const string = await generateImage(testPrompt);
+it('should respond with a base64 encoded string', async () => {
+  const responseObj = await generateImage(testPrompt);
 
-  expect(typeof string).toBe('string');
-})
-
-it('should not respond with a url', async () => {
-  const string = await generateImage(testPrompt);
-
-  expect(string).not.toContain('https://')
+  expect(responseObj).toHaveProperty('b64_json')
 })
 
 it('should only call dalleAPI once', async () => {


### PR DESCRIPTION
## DalleImageController Refactor and Test

- renamed dalleImageController.generateImage to dalleImageController.getImageUrl
- moved convertStrToFileName function to utils folder
- moved openai client instantiation logic to utils folder
- created services folder
- moved the logic that interfaces with Dalle API to services folder (generateImage)
- refactored generateImage
- added test for generateImage

**dalleService.generateImage Refactor**
the request to dalle API now returns a a base64 encoded string instead of a url. This eliminates the need to make a request to retrieve the png from the generated image url. The b64 string is now converted to a buffer, which is passed directly to S3 upload. 

Original data flow: url -> external request -> png -> blob -> arrayBuffer -> buffer -> stream  -> s3 upload
Refactored data flow:  base64 -> buffer -> s3 upload
refactored function completes execution an average of 400ms faster than original